### PR TITLE
feat(home-manager): add bashInteractive for Linux containers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 DOTPATH    := $(realpath $(dir $(lastword $(MAKEFILE_LIST))))
 CANDIDATES := $(wildcard .??*)
-EXCLUSIONS := .DS_Store .git .gitignore .github .bashrc .reporc .gitconfig .gitconfig_global .mise.toml
+EXCLUSIONS := .DS_Store .git .gitignore .github .claude .bashrc .reporc .gitconfig .gitconfig_global .mise.toml
 DIRECTORY  := .zsh
 DOTFILES   := $(filter-out $(EXCLUSIONS) $(DIRECTORY), $(CANDIDATES))
 

--- a/NIX_QUICK_START.md
+++ b/NIX_QUICK_START.md
@@ -68,8 +68,13 @@ echo "home-manager/modules/local.nix" >> .gitignore
 # home.nixでlocal.nixをインポート（コメント解除）
 # imports = [ ./modules/local.nix ];
 
-# 適用
-home-manager switch --impure --flake .#"$(whoami)@$(uname -m)-$(uname -s | tr '[:upper:]' '[:lower:]')"
+# 適用（flake.nixに定義済みの構成名を指定する）
+# macOS (Apple Silicon)
+home-manager switch --impure --flake .#"illumination-k@aarch64-darwin"
+# Linux (x86_64)
+home-manager switch --impure --flake .#"illumination-k@x86_64-linux"
+# Linux (ARM64)
+home-manager switch --impure --flake .#"illumination-k@aarch64-linux"
 ```
 
 ### 3. パッケージモジュールを有効化
@@ -113,8 +118,8 @@ home-manager switch --impure --flake .
 ### ビルドエラー
 
 ```bash
-# 詳細なトレースを表示
-nix build --show-trace .#homeConfigurations."$(whoami)@$(uname -m)-$(uname -s | tr '[:upper:]' '[:lower:]')".activationPackage
+# 詳細なトレースを表示（構成名は環境に合わせて選ぶ）
+nix build --show-trace .#homeConfigurations."illumination-k@aarch64-darwin".activationPackage
 ```
 
 ### ロールバック

--- a/bin/brew_installer.sh
+++ b/bin/brew_installer.sh
@@ -15,10 +15,10 @@ if type brew >/dev/null 2>&1; then
 	echo "brew is already installed"
 else
 	if type curl >/dev/null 2>&1; then
-		if [ -x /usr/bin/rudy ]; then
+		if [ -x /usr/bin/ruby ]; then
 			/usr/bin/ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"
 		else
-			die '/usr/bin/rudy required. if you want to use other ruby, please run `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`'
+			die '/usr/bin/ruby required. if you want to use other ruby, please run `ruby -e "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/install)"`'
 		fi
 	else
 		die "curl required"

--- a/docker/entrypoint-dev.sh
+++ b/docker/entrypoint-dev.sh
@@ -39,6 +39,9 @@ NL="$(printf '\nx')"
 NL="${NL%x}"
 : > "${SSH_DIR}/environment"
 chmod 600 "${SSH_DIR}/environment"
+# PATHは常に書き出す（sshdの組み込みデフォルトPATHにはnixのbinが含まれず、
+# git/claude等がssh経由で見つからなくなるため）
+printf 'PATH=%s\n' "${PATH}" >> "${SSH_DIR}/environment"
 for var in ${EXPORT_VARS}; do
   case "${var}" in
     *[!A-Za-z0-9_]* | [0-9]*)

--- a/etc/install.sh
+++ b/etc/install.sh
@@ -3,13 +3,19 @@
 DOTPATH=~/dotfiles
 GITHUB_URL="https://github.com/illumination-k/dotfiles.git"
 
+die() {
+	echo "$@" >&2
+	exit 1
+}
+
+[ -e "$DOTPATH" ] && die "$DOTPATH already exists"
+
 # git が使えるなら git
 if type git >/dev/null 2>&1; then
 	git clone --recursive "$GITHUB_URL" "$DOTPATH"
 
 # 使えない場合は curl か wget を使用する
 elif type curl >/dev/null 2>&1 || type wget >/dev/null 2>&1; then
-	mkdir -p $DOTPATH
 	tarball="https://github.com/illumination-k/dotfiles/archive/master.tar.gz"
 
 	# download by curl or wget

--- a/home-manager/modules/git.nix
+++ b/home-manager/modules/git.nix
@@ -7,6 +7,9 @@
     # 基本設定
     settings = {
       user.name = "illumination-k";
+      # デフォルトのemail（コンテナ等local.nix無しの環境でcommitできるように）
+      # マシン固有のemailはlocal.nixで上書きする
+      user.email = lib.mkDefault "illumination.k.27@gmail.com";
 
       core = {
         filemode = false;
@@ -94,4 +97,7 @@
 
   # .gitignore_globalファイル配置
   home.file.".gitignore_global".source = ../../.gitignore_global;
+
+  # includeIfが参照するpersonal設定（未配置だとincludeが空振りする）
+  home.file.".gitconfig-personal".source = ../../.gitconfig-personal;
 }

--- a/home-manager/modules/local.nix.template
+++ b/home-manager/modules/local.nix.template
@@ -3,7 +3,7 @@
 {
   # マシン固有のgit設定
   programs.git = {
-    userEmail = "your-actual-email@example.com";  # 各マシンで変更
+    settings.user.email = "your-actual-email@example.com";  # 各マシンで変更
   };
 
   # マシン固有の環境変数

--- a/home-manager/modules/programs.nix
+++ b/home-manager/modules/programs.nix
@@ -79,6 +79,7 @@
     getent       # getent
     xsel         # クリップボード
     openssh      # dev pod用sshd（ssh/sftp/ssh-keygen含む）
+    bashInteractive # bash前提のスクリプト用（最小コンテナにはbashが無い）
 
     # コンテナ最小環境で欠けがちな基盤ツール
     # （coreutilsにtarは含まれない。miseのランタイム展開等に必須）

--- a/home-manager/modules/shell.nix
+++ b/home-manager/modules/shell.nix
@@ -52,9 +52,13 @@ in {
       ${builtins.readFile ../../.zsh/80_functions.zsh}
 
       # zshrc コンパイル
-      if [ ! -f ~/.zshrc.zwc ] || [ ~/.zshrc -nt ~/.zshrc.zwc ]; then
-          zcompile ~/.zshrc
+      # home-manager配下の~/.zshrcはnix storeへのsymlinkでmtimeが常に1970のため、
+      # -ntによる比較は使えない。リンク先store pathの変化で再コンパイルを判定する。
+      zshrc_target="$(readlink -f ~/.zshrc 2>/dev/null || echo ~/.zshrc)"
+      if [ ! -f ~/.zshrc.zwc ] || [ "$(cat ~/.zshrc.zwc.src 2>/dev/null)" != "$zshrc_target" ]; then
+          zcompile ~/.zshrc && echo "$zshrc_target" > ~/.zshrc.zwc.src
       fi
+      unset zshrc_target
 
       # ローカルプロファイル読み込み
       if [ -f ~/.local_profile ]; then
@@ -77,14 +81,51 @@ in {
       if has_cmd uv; then
           eval "$(uv generate-shell-completion zsh)"
       fi
+
+      # ===== 30_alias.zsh（shellAliasesで表現できない構文） =====
+      # 複数ファイルのmv 例 zmv *.txt *.txt.bk
+      autoload -Uz zmv
+      alias zmv='noglob zmv -W'
+
+      # suffix alias
+      alias -s py=python3
+      alias -s sh=bash
+      alias -s html='open'
+
+      function extract() {
+          case $1 in
+          *.tar.gz | *.tgz) tar xzvf $1 ;;
+          *.tar.xz) tar Jxvf $1 ;;
+          *.zip) unzip $1 ;;
+          *.lzh) lha e $1 ;;
+          *.tar.bz2 | *.tbz) tar xjvf $1 ;;
+          *.tar.Z) tar zxvf $1 ;;
+          *.gz) gzip -d $1 ;;
+          *.bz2) bzip2 -dc $1 ;;
+          *.Z) uncompress $1 ;;
+          *.tar) tar xvf $1 ;;
+          *.arj) unarj $1 ;;
+          esac
+      }
+      alias -s {gz,tgz,zip,lzh,bz2,tbz,Z,tar,arj,xz}=extract
+
+      # global alias
+      alias -g A='| awk'
+      alias -g C='| c'
+      alias -g W='| wc -w'
+      alias -g G='| grep'
+      alias -g H='| head'
+      alias -g T='| tail'
+      alias -g L='| less -R'
+      alias -g X='| xargs'
     '';
 
     # ===== 30_alias.zsh =====
     shellAliases = {
       # ls（ezaまたはplatform依存）
-      ls = "exa -F";
-      lsa = "exa -aF";
-      tree = "exa -hTF --ignore-glob='.git'";
+      ls = "eza -F";
+      lsa = "eza -aF";
+      tree = "eza -hTF --ignore-glob='.git'";
 
       # cd shortcuts
       ".." = "cd ..";
@@ -173,7 +214,9 @@ in {
   };
 
   # 設定ファイルの配置
-  home.file.".starship.toml".source = ../../.starship.toml;
+  # starshipはデフォルトで~/.config/starship.tomlのみを読む
+  # （legacyの.zsh/40_prompt.zshはSTARSHIP_CONFIG=~/.starship.tomlを設定していた）
+  xdg.configFile."starship.toml".source = ../../.starship.toml;
   home.file.".colorrc".source = ../../.colorrc;
 
 }


### PR DESCRIPTION
## 概要
1. Linux（dev pod / コンテナ）向けの `home.packages` に `bashInteractive` を追加
2. スクリプト・home-manager設定のtypoと環境依存バグの修正をまとめて含む（Makefile, NIX_QUICK_START.md, brew_installer.sh, entrypoint-dev.sh, install.sh, git.nix, local.nix.template, shell.nix）

## 背景
- nix管理のパッケージにbashが含まれておらず、最小コンテナ環境では `#!/bin/bash` 前提のスクリプト（各種インストーラ等）が動かない
- `shell.nix` の `alias -s sh=bash` もシステム側のbashに依存していた
- macOSは `/bin/bash` が標準で存在するためLinux専用リストのみに追加

🤖 Generated with [Claude Code](https://claude.com/claude-code)