### PR TITLE
feat(home-manager): add gawk and diffutils to Linux packages

### DIFF
--- a/home-manager/modules/programs.nix
+++ b/home-manager/modules/programs.nix
@@ -76,6 +76,8 @@
     findutils    # find, xargs等
     gnugrep      # grep
     gnused       # sed
+    gawk         # awk（goawk等の間借りだとリンク切れしうるため明示的に持つ）
+    diffutils    # diff, cmp（他パッケージのstoreパス依存だとGCで消えうる）
     getent       # getent
     xsel         # クリップボード
     openssh      # dev pod用sshd（ssh/sftp/ssh-keygen含む）


### PR DESCRIPTION
## 概要

Linux（コンテナ）プロファイルに `gawk` と `diffutils` を明示的に追加する。

これまで awk / diff は他パッケージ経由の間接的な供給に依存しており、

- awk: goawk 等への間借りだと Go のバージョンアップでリンクが切れうる
- diff: 他パッケージの store パス依存だと nix GC で消えうる

ため、home-manager のプロファイルで直接持つのが恒久対応。

## 検証

- nix eval で `illumination-k@aarch64-linux` の `home.packages` に gawk / diffutils が含まれることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)