### PR TITLE
feat(home-manager,docker): add libsecret and .NET runtime libs, k=kubectl alias

### DIFF
--- a/docker/images.nix
+++ b/docker/images.nix
@@ -69,6 +69,14 @@ let
     xz
     curl
     stdenv.cc.cc # libstdc++ / libgcc_s
+
+    # .NET SDK/ランタイム（mise等のプリビルド配布物）が動的ロードする依存
+    icu          # libicuuc/libicui18n（グローバリゼーション。無いとdotnetが起動しない）
+    krb5         # libgssapi_krb5（Kerberos認証。HttpClient等が参照）
+    lttng-ust    # liblttng-ust（トレーシング。参照だけされるので置いておく）
+
+    # シークレットストア（git-credential-manager等がDllImportでロード）
+    libsecret
   ]);
 
   # runtime用/etc（rootのみ。ログインユーザーはdev側で追加）

--- a/home-manager/modules/programs.nix
+++ b/home-manager/modules/programs.nix
@@ -80,6 +80,7 @@
     diffutils    # diff, cmp（他パッケージのstoreパス依存だとGCで消えうる）
     getent       # getent
     xsel         # クリップボード
+    libsecret    # secret-tool CLI + libsecret-1.so（GCで消えないようprofileに固定）
     openssh      # dev pod用sshd（ssh/sftp/ssh-keygen含む）
     bashInteractive # bash前提のスクリプト用（最小コンテナにはbashが無い）
 

--- a/home-manager/modules/shell.nix
+++ b/home-manager/modules/shell.nix
@@ -137,6 +137,9 @@ in {
       # docker
       d = "docker";
 
+      # kubernetes
+      k = "kubectl";
+
       # git
       g = "git";
       gu = "gitui";  # Git TUI


### PR DESCRIPTION
## 変更内容

### .NET / libsecret のネイティブ依存 (`docker/images.nix`)
`NIX_LD_LIBRARY_PATH` に以下を追加。mise等で入れるプリビルドのdotnet SDKはnix-ld経由で動的リンクするため、ここに置く。

- `icu` — libicuuc/libicui18n（無いとdotnetが起動しない）
- `krb5` — libgssapi_krb5（HttpClient等のKerberos認証）
- `lttng-ust` — dotnetが参照するトレーシングライブラリ
- `libsecret` — git-credential-manager等がDllImportでロード

### home-manager (`programs.nix`)
- Linuxセクションに `libsecret` を追加（`secret-tool` CLI + profileへのGC root化）

### shell alias (`shell.nix`)
- `k` = `kubectl`

## 検証
ローカルにnixが無いため、`nixos/nix` コンテナで `docker-dev` / `docker-runtime` の derivation を評価し、`NIX_LD_LIBRARY_PATH` に icu4c-76.1 / krb5-1.22.2-lib / lttng-ust-2.15.1 / libsecret-0.21.7 が含まれることを確認済み。フルビルドはCIで確認。

🤖 Generated with [Claude Code](https://claude.com/claude-code)