### PR TITLE
feat(home-manager,docker): add hunk and entra-helper, bump herdr to 0.7.4

### DIFF
--- a/docker/images.nix
+++ b/docker/images.nix
@@ -23,30 +23,33 @@ let
   homeDir = "/home/${username}";
   binPath = "${homeDir}/result/home-path/bin";
 
-  # herdr: pinしたnixpkgsにまだ存在しない場合は公式リリースの
-  # 静的バイナリへフォールバックする（flake update後は自動でnixpkgs版になる）。
-  herdr = pkgs.herdr or (
+  # herdr: nixpkgs版が下記バージョンより古い（or 無い）場合は公式リリースの
+  # 静的バイナリへフォールバックする（flake updateでnixpkgsが追いつけば自動でnixpkgs版になる）。
+  herdrMinVersion = "0.7.4";
+  herdrBin =
     let
-      version = "0.7.1";
       arch = pkgs.stdenv.hostPlatform.parsed.cpu.name; # x86_64 / aarch64
       sha256s = {
-        x86_64 = "b965acaffc2c22f54b6e6c64af7cf8e98a3f4ac2622630a0599c67a4b9d8a654";
-        aarch64 = "3d757ac30c631e79dc45038c3ecc6423fe13a89f9cffa0f415aedd2c27f1576c";
+        x86_64 = "bc0fc02d4ba500f9cac2353a43e67fe036785ecca6eb55378e050fac3c103059";
+        aarch64 = "544e0002de42806d1ab64ccdef3a7e7414f24717b0b6b022bc9e57d2eefd26a2";
       };
     in
     pkgs.stdenvNoCC.mkDerivation {
       pname = "herdr-bin";
-      inherit version;
+      version = herdrMinVersion;
       src = pkgs.fetchurl {
-        url = "https://github.com/ogulcancelik/herdr/releases/download/v${version}/herdr-linux-${arch}";
+        url = "https://github.com/ogulcancelik/herdr/releases/download/v${herdrMinVersion}/herdr-linux-${arch}";
         sha256 = sha256s.${arch};
       };
       dontUnpack = true;
       installPhase = ''
         install -Dm755 $src $out/bin/herdr
       '';
-    }
-  );
+    };
+  herdr =
+    if pkgs ? herdr && pkgs.lib.versionAtLeast pkgs.herdr.version herdrMinVersion
+    then pkgs.herdr
+    else herdrBin;
 
   # FHS互換の動的リンカ:
   # このイメージは/nix/storeベースで/lib64等のFHSパスが無いため、Nix外の

--- a/flake.lock
+++ b/flake.lock
@@ -21,6 +21,26 @@
         "type": "github"
       }
     },
+    "entra-helper": {
+      "inputs": {
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1784210357,
+        "narHash": "sha256-Mvrw/GkCssdSpk1mia3oKvM1w2XNwG4Rd6ME2WswSwI=",
+        "owner": "illumination-k",
+        "repo": "entra-helper",
+        "rev": "231d2bb579221e08a9bbdd5e8de1ee0e23a2e6c5",
+        "type": "github"
+      },
+      "original": {
+        "owner": "illumination-k",
+        "repo": "entra-helper",
+        "type": "github"
+      }
+    },
     "flake-utils": {
       "inputs": {
         "systems": "systems"
@@ -78,6 +98,7 @@
     "root": {
       "inputs": {
         "codex": "codex",
+        "entra-helper": "entra-helper",
         "home-manager": "home-manager",
         "nixpkgs": "nixpkgs"
       }

--- a/flake.nix
+++ b/flake.nix
@@ -13,9 +13,14 @@
       url = "github:sadjow/codex-cli-nix";
       inputs.nixpkgs.follows = "nixpkgs";
     };
+
+    entra-helper = {
+      url = "github:illumination-k/entra-helper";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
   };
 
-  outputs = { self, nixpkgs, home-manager, codex, ... }:
+  outputs = { self, nixpkgs, home-manager, codex, entra-helper, ... }:
     let
       # サポートするシステム
       # （x86_64-darwinはnixpkgs 26.11でサポート打ち切りのため除外）
@@ -30,6 +35,7 @@
           pkgs = import nixpkgs {
             inherit system;
             config.allowUnfree = true;
+            overlays = [ entra-helper.overlays.default ];
           };
           isDarwin = pkgs.stdenv.isDarwin;
           isLinux = pkgs.stdenv.isLinux;
@@ -65,6 +71,7 @@
           pkgs = import nixpkgs {
             inherit system;
             config.allowUnfree = true;
+            overlays = [ entra-helper.overlays.default ];
           };
           homeConfiguration = self.homeConfigurations."illumination-k@${system}";
         });

--- a/home-manager/modules/programs.nix
+++ b/home-manager/modules/programs.nix
@@ -24,6 +24,7 @@
     ghq          # Gitリポジトリ管理
     delta        # diff表示改善 (git-delta)
     gitui        # ターミナルUI Gitクライアント
+    hunk         # agent向け変更セットのターミナルdiffビューア
 
     # Rust製CLIツール
     eza          # ls代替（exaの後継）
@@ -61,6 +62,9 @@
 
     # Kubernetes
     kubectl      # Kubernetes CLI
+
+    # 認証
+    entra-helper # Entra IDのaccess tokenを発行するCLI（overlay経由・自作）
 
     # シェル環境
     zsh


### PR DESCRIPTION
## 変更内容

- **hunk 追加**: pin済みnixpkgsに入っている `hunk` 0.17.0（agent向け変更セットのターミナルdiffビューア）を `home.packages` に追加
- **entra-helper 追加**: [illumination-k/entra-helper](https://github.com/illumination-k/entra-helper) をflake input + overlayで追加（`nixpkgs.follows`でpin共有、main HEAD `231d2bb` をlock）。「認証」セクションとして `home.packages` に追加
- **herdr 更新**: フォールバックバイナリを 0.7.1 → 0.7.4 に更新。条件を「nixpkgs版が `herdrMinVersion` (0.7.4) 以上ならnixpkgs版、未満ならピン版バイナリ」に変更。現pinのnixpkgsは 0.7.3 のためピン版 0.7.4 が使われ、flake updateで追いつけば自動でnixpkgs版に切り替わる

## 検証

nixos/nix コンテナ（aarch64-linux）で確認:

- `docker-dev` イメージのderivation生成が通り、クロージャに `herdr-bin-0.7.4` / `hunk-0.17.0` / `entra-helper-231d2bb` が含まれることを確認
- entra-helper は実ビルドし `entra-helper version 231d2bb` の出力を確認（vendorHashはpin済みnixpkgsのGoで問題なし）
- `illumination-k@aarch64-darwin` の homeConfiguration は評価のみ確認（darwinビルド環境なし）

🤖 Generated with [Claude Code](https://claude.com/claude-code)