### PR TITLE
feat(home-manager,docker): bump herdr to 0.7.5, add claude-code latest fallback

### DIFF
--- a/docker/images.nix
+++ b/docker/images.nix
@@ -25,13 +25,13 @@ let
 
   # herdr: nixpkgs版が下記バージョンより古い（or 無い）場合は公式リリースの
   # 静的バイナリへフォールバックする（flake updateでnixpkgsが追いつけば自動でnixpkgs版になる）。
-  herdrMinVersion = "0.7.4";
+  herdrMinVersion = "0.7.5";
   herdrBin =
     let
       arch = pkgs.stdenv.hostPlatform.parsed.cpu.name; # x86_64 / aarch64
       sha256s = {
-        x86_64 = "bc0fc02d4ba500f9cac2353a43e67fe036785ecca6eb55378e050fac3c103059";
-        aarch64 = "544e0002de42806d1ab64ccdef3a7e7414f24717b0b6b022bc9e57d2eefd26a2";
+        x86_64 = "3dc83288073e4c2d3c679a30e7be97bcca9141c6fd17dbbb9219142e95c59253";
+        aarch64 = "32e763a1499a6b694b1d708e4f062b743be1da9f34fcfa4d212d6db6fe09a8b9";
       };
     in
     pkgs.stdenvNoCC.mkDerivation {

--- a/home-manager/home.nix
+++ b/home-manager/home.nix
@@ -1,5 +1,31 @@
 { config, pkgs, lib, isDarwin, isLinux, codex, system, ... }:
 
+let
+  # claude-code: nixpkgs版が下記バージョンより古い場合は公式リリースの
+  # ネイティブバイナリへフォールバックする（docker/images.nixのherdrと
+  # 同じパターン。flake updateでnixpkgsが追いつけば自動でnixpkgs版になる）。
+  # 更新時は https://downloads.claude.ai/claude-code-releases/<ver>/manifest.json
+  # からversionと各platformのchecksumを転記する
+  claudeMinVersion = "2.1.220";
+  claudeChecksums = {
+    "darwin-arm64" = "8addc857f3fe64d5a0368af9ee50321b50afb4a6918ba3ef018ab84f5dbbe081";
+    "darwin-x64" = "dca7be0aa7d3d924836d440e0c6d8e3d47ef3c8e61fa5809b54b9017170ce2f3";
+    "linux-arm64" = "159e4a51d796f3bf14677577100f7efb845611b1ceaf0c30cbd8d4650d942185";
+    "linux-x64" = "674f61f20ff306f3100cf9200e4c36c4b70278b5bef2884549819b942a89c863";
+  };
+  claudePlatformKey =
+    "${pkgs.stdenvNoCC.hostPlatform.node.platform}-${pkgs.stdenvNoCC.hostPlatform.node.arch}";
+  claudeCode =
+    if lib.versionAtLeast pkgs.claude-code.version claudeMinVersion
+    then pkgs.claude-code
+    else pkgs.claude-code.overrideAttrs (old: {
+      version = claudeMinVersion;
+      src = pkgs.fetchurl {
+        url = "https://downloads.claude.ai/claude-code-releases/${claudeMinVersion}/${claudePlatformKey}/claude";
+        sha256 = claudeChecksums.${claudePlatformKey};
+      };
+    });
+in
 {
   # Home Managerバージョン
   home.stateVersion = "23.11";
@@ -17,7 +43,7 @@
   home.packages = with pkgs; [
     hello  # 動作確認用
     codex.packages.${system}.codex  # OpenAI Codex CLI (Rust版)
-    claude-code  # Anthropic Claude Code CLI
+    claudeCode  # Anthropic Claude Code CLI（claudeMinVersionフォールバック付き）
   ];
 
   # 環境変数


### PR DESCRIPTION
## 変更内容

- **herdr 0.7.4 → 0.7.5**: `docker/images.nix` の `herdrMinVersion` とバイナリsha256を更新
- **claude-code 最新化**: nixpkgs版（現在2.1.217）が `claudeMinVersion`（2.1.220）より古い場合、公式リリースのネイティブバイナリへフォールバックするパターンを `home-manager/home.nix` に追加。`docker/images.nix` のherdrと同じ方式で、flake updateでnixpkgsが追いつけば自動でnixpkgs版に戻る

checksumは https://downloads.claude.ai/claude-code-releases/2.1.220/manifest.json から転記。

🤖 Generated with [Claude Code](https://claude.com/claude-code)